### PR TITLE
Customized the trade description + useless ";" removed

### DIFF
--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -117,20 +117,14 @@ div.trade-description {
     border-radius: 3px;
     color: black;
     opacity: 0.5;
-    -webkit-animation: description-init 1s forwards;
-}
-@-webkit-keyframes description-apparition {
-    0%   { opacity: 0.5; }
-    100% { opacity: 1; }
-}
-@-webkit-keyframes description-init {
-    from { opacity: 1; }
-    to { opacity: 0.5; }
+    -webkit-transition: opacity 0.5s ease-in-out;
+    transition: opacity 0.5s ease-in-out;
+
 }
 .trade-description:hover p {
     padding: 12px 5px;
     color: black;
-    -webkit-animation: description-apparition 0.5s forwards;
+    opacity: 1;
 }
 .trade-description .more-text, .trade-description .open-trade {
     position: absolute;


### PR DESCRIPTION
Hey there, I tought the description area was a bit too "solid" so I smoothed it !
There was also 2 semi-colons wich had nothing to do here so I removed it.  
This is the current look with my modifications:
![loungedestroyer](https://cloud.githubusercontent.com/assets/3439246/4403963/2f52a7ec-44ab-11e4-876b-6899092731aa.png)
