### PR TITLE
Fixed window.close() not working

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,7 +13,7 @@ function onload() {
         });
     });
     $("#close-btn").click(function(){
-        window.close();
+        window.open(location, '_self').close();
     });
 }
 


### PR DESCRIPTION
When clicking on the close button (in the popup), nothing happens.
Fixed with this "hack".
Source: http://stackoverflow.com/questions/19761241/window-close-and-self-close-do-not-close-the-window-in-chrome
