### PR TITLE
Removed redundant loops and querySelectors

### DIFF
--- a/app/bet.js
+++ b/app/bet.js
@@ -16,12 +16,13 @@ function enableAuto(worth, match, tries, error) {
 		            ordinalEnding === "3" ? "rd":
 		            "th";
 
+	var isBetStatusTypeValid = false;
 	var typeSpansTextContent = "";
 	var worthContainerClass = "worth-container";
 	var destroyerInfoButtonText = "Disable auto-";
 
 	if (betStatus.type === "autoBet") {
-
+		isBetStatusTypeValid = true;
 		var worth = worth === -1 ? "key(s)" :
 		                      "$"+(worth || 0).toFixed(2);
 		typeSpansTextContent = "betting";
@@ -31,17 +32,19 @@ function enableAuto(worth, match, tries, error) {
 	    document.querySelector(".destroyer.auto-info .match-link").href = "match?m="+match;
 
 	} else if (betStatus.type === "autoReturn") {
+		isBetStatusTypeValid = true;
 		typeSpansTextContent = "returning";
 		worthContainerClass += " hidden";
 		destroyerInfoButtonText += "return";
 	}
 
-	document.querySelector(".destroyer.auto-info .worth-container").className = worthContainerClass;
-	document.querySelector(".destroyer.auto-info button").textContent = destroyerInfoButtonText;
-
-	var typeSpans = document.querySelectorAll(".destroyer.auto-info .type");
-	for (var i = 0; i < typeSpans.length; ++i) {
-		typeSpans[i].textContent = typeSpansTextContent;
+	if(isBetStatusTypeValid){
+		document.querySelector(".destroyer.auto-info .worth-container").className = worthContainerClass;
+		document.querySelector(".destroyer.auto-info button").textContent = destroyerInfoButtonText;
+		var typeSpans = document.querySelectorAll(".destroyer.auto-info .type");
+		for (var i = 0; i < typeSpans.length; ++i) {
+			typeSpans[i].textContent = typeSpansTextContent;
+		}
 	}
 
 	// update info-box in top-right

--- a/app/bet.js
+++ b/app/bet.js
@@ -16,28 +16,32 @@ function enableAuto(worth, match, tries, error) {
 		            ordinalEnding === "3" ? "rd":
 		            "th";
 
+	var typeSpansTextContent = "";
+	var worthContainerClass = "worth-container";
+	var destroyerInfoButtonText = "Disable auto-";
+
 	if (betStatus.type === "autoBet") {
+
 		var worth = worth === -1 ? "key(s)" :
 		                      "$"+(worth || 0).toFixed(2);
-
-		document.querySelector(".destroyer.auto-info .worth-container").className = "worth-container";
+		typeSpansTextContent = "betting";
+		destroyerInfoButtonText += "bet";
    		//document.querySelector(".destroyer.auto-info .worth").textContent = worth;
 	    document.querySelector(".destroyer.auto-info .match-link").textContent = match;
 	    document.querySelector(".destroyer.auto-info .match-link").href = "match?m="+match;
-	    document.querySelector(".destroyer.auto-info button").textContent = "Disable auto-bet";
 
-	    var typeSpans = document.querySelectorAll(".destroyer.auto-info .type");
-		for (var i = 0; i < typeSpans.length; ++i) {
-			typeSpans[i].textContent = "betting";
-		}
 	} else if (betStatus.type === "autoReturn") {
-		document.querySelector(".destroyer.auto-info .worth-container").className = "worth-container hidden";
-		document.querySelector(".destroyer.auto-info button").textContent = "Disable auto-return";
+		typeSpansTextContent = "returning";
+		worthContainerClass += " hidden";
+		destroyerInfoButtonText += "return";
+	}
 
-		var typeSpans = document.querySelectorAll(".destroyer.auto-info .type");
-		for (var i = 0; i < typeSpans.length; ++i) {
-			typeSpans[i].textContent = "returning";
-		}
+	document.querySelector(".destroyer.auto-info .worth-container").className = worthContainerClass;
+	document.querySelector(".destroyer.auto-info button").textContent = destroyerInfoButtonText;
+
+	var typeSpans = document.querySelectorAll(".destroyer.auto-info .type");
+	for (var i = 0; i < typeSpans.length; ++i) {
+		typeSpans[i].textContent = typeSpansTextContent;
 	}
 
 	// update info-box in top-right


### PR DESCRIPTION
I noticed that betStatus's of type autoBet and autoReturn both shared some code.

```
document.querySelector(".destroyer.auto-info .worth-container").className = someClass;
document.querySelector(".destroyer.auto-info button").textContent = someText;
for (var i = 0; i < typeSpans.length; ++i) {
  typeSpans[i].textContent = someText;
}
```
So I pulled them out - https://github.com/Jakehp/LoungeDestroyer/commit/4a883b03fe3f94e6840db156474eca811d219ed8 - and added a check - https://github.com/Jakehp/LoungeDestroyer/commit/01c01b0d56ff7aae3edd7c7c0141fb938aea8049 - to make sure it only runs if one of the previous If-statements were true (to retain logic before I started refactoring).