### PR TITLE
Add Total profit by day in myprofile (bet history tab)

### DIFF
--- a/app/inject.js
+++ b/app/inject.js
@@ -713,8 +713,12 @@ var itemObs = new MutationObserver(function(records) {
             initiateItemObjectForElementList($('#ajaxCont.full .oitm'), true);
 
             var betHistoryColSett = LoungeUser.userSettings.betHistoryTotalColumn;
+            var currentDate       = null;
+            var totalByDate       = 0;
+            var format            = 'YYYY-MM-DD';
             if(['1', '2'].indexOf(betHistoryColSett) !== -1) {
-                $('table tbody tr:visible').each(function(i, v) {
+                var $table = $('table tbody tr:visible');
+                $table.each(function(i, v) {
                     var total = 0;
 
                     // Won items
@@ -731,13 +735,7 @@ var itemObs = new MutationObserver(function(records) {
                         });
                     }
 
-                    if(total > 0) {
-                        text = '+ ' + convertPrice(total, true);
-                    } else if(total < 0) {
-                        text = '- ' + convertPrice(Math.abs(total), true);
-                    } else {
-                        text = convertPrice(0, true);
-                    }
+                    var text = convertTextPrice(total);
 
                     var newTd = $('<td></td>').text(text);
 
@@ -747,7 +745,24 @@ var itemObs = new MutationObserver(function(records) {
                             'both enabled, then it might be possible that the item does not have a betting/market value."> (?)</small>');
                     }
 
+
                     $('td:eq(5)', v).after(newTd);
+
+                    // Add total profit line
+                    var date   = moment($('td:last-child', v).text());
+
+                    if (currentDate == null || (currentDate.format(format) == date.format(format))) {
+                        totalByDate += total;
+                    } else {
+                        $(v).before(buildTotalLine(currentDate.format(format), totalByDate));
+                        totalByDate = total;
+                    }
+
+                    if ($table.length == i+1) {
+                        $(v).after(buildTotalLine(currentDate.format(format), totalByDate));
+                    }
+
+                    currentDate = date;
                 });
 
                 // Adjust the column width because we added another column
@@ -774,3 +789,24 @@ function convertLoungeTime(loungeTimeString) {
 
     return loungeTimeString;
 }
+
+function convertTextPrice(total) {
+    if(total > 0) {
+        return '+ ' + convertPrice(total, true);
+    } else if(total < 0) {
+        return '- ' + convertPrice(Math.abs(total), true);
+    } else {
+        return convertPrice(0, true);
+    }
+}
+
+function buildTotalLine(date, total) {
+    var textTotal = '<td colspan="2"></td>' +
+        '<td colspan="3">Total on ' + date + '</td>' +
+        '<td colspan="1"></td>' +
+        '<td class="' + (total < 0 ? 'lost' : 'won') + '">' + convertTextPrice(total) + '</td><td></td>';
+    var totalLine = $('<tr class="ld-total"></tr>').append(textTotal);
+
+    return totalLine;
+}
+


### PR DESCRIPTION
Hello,

With this feature, you can see the total profit (lost or won) by each days.

Default:
![Screenshot](https://i.gyazo.com/5a4cc61a839146a7e42cf89d63134ca1.png)

Glasslounge:
![Screenshot](https://i.gyazo.com/cf0c6d337fb38a41b0a70b970da3c8a9.png)

CleanLounge Night:
![Screenshot](https://i.gyazo.com/0db3a9113f4e11b6c79a029fdd9029c3.png)

I respected the coding standard on my feature but gulp is not agree with approximately 30 others line. Do you want another one PR to fix it ?

If you like my PR, I will add the full profit in the button bar (and maybe an average by month)