### PR TITLE
Added return keypress ignore to /search & /addtrade itemfilter input field

### DIFF
--- a/app/inject.js
+++ b/app/inject.js
@@ -458,10 +458,12 @@ function init() {
             });
         }
 
-        if (document.URL.indexOf('/search') != -1) {
+        if (document.URL.indexOf('/search') !== -1) {
             //disable post on /search input field
-            $('#itemfilter').keypress(function(e){
-                if ( e.which == 13 ) e.preventDefault();
+            $('#itemfilter').keypress(function(e) {
+                if (e.which === 13) { 
+                    e.preventDefault();
+                }
             });
         }
 

--- a/app/inject.js
+++ b/app/inject.js
@@ -458,8 +458,8 @@ function init() {
             });
         }
 
-        if (document.URL.indexOf('/search') !== -1) {
-            //disable post on /search input field
+        if (document.URL.indexOf('/search') !== -1 || document.URL.indexOf('/addtrade') !== -1) {
+            //disable post on /search and /addtrade input fields
             $('#itemfilter').keypress(function(e) {
                 if (e.which === 13) { 
                     e.preventDefault();

--- a/app/inject.js
+++ b/app/inject.js
@@ -458,12 +458,12 @@ function init() {
             });
         }
 
-		if (document.URL.indexOf('/search') != -1) {
-			//disable post on /search input field
-			$('#itemfilter').keypress(function(e){
-				if ( e.which == 13 ) e.preventDefault();
-			});
-		}
+        if (document.URL.indexOf('/search') != -1) {
+            //disable post on /search input field
+            $('#itemfilter').keypress(function(e){
+                if ( e.which == 13 ) e.preventDefault();
+            });
+        }
 
         $ldContainer.find('#bet-time').val(LoungeUser.userSettings.autoDelay);
         $ldContainer.find('#accept-time').val(LoungeUser.userSettings.acceptDelayv2);

--- a/app/inject.js
+++ b/app/inject.js
@@ -458,6 +458,13 @@ function init() {
             });
         }
 
+		if (document.URL.indexOf('/search') != -1) {
+			//disable post on /search input field
+			$('#itemfilter').keypress(function(e){
+				if ( e.which == 13 ) e.preventDefault();
+			});
+		}
+
         $ldContainer.find('#bet-time').val(LoungeUser.userSettings.autoDelay);
         $ldContainer.find('#accept-time').val(LoungeUser.userSettings.acceptDelayv2);
 


### PR DESCRIPTION
When filtering items on http://csgolounge.com/search if you press return it posts and it really shouldn't. It is frustrating so here's a fix.